### PR TITLE
Add buildable folder support

### DIFF
--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -580,6 +580,8 @@ targets:
             subpath: include/$(PRODUCT_NAME)
       - path: Resources
         type: folder
+      - path: Sources
+        type: synchronized
       - path: Path/To/File.asset
         resourceTags: [tag1, tag2]
 ```

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -542,6 +542,7 @@ A source can be provided via a string (the path) or an object of the form:
 	- `file`: a file reference with a parent group will be created (Default for files or directories with extensions)
 	- `group`: a group with all it's containing files. (Default for directories without extensions)
 	- `folder`: a folder reference.
+	- `synchronized`: a synchronized group that automatically updates its contents when files are added or removed in Xcode. This is useful for directories that are frequently modified.
 - [ ] **headerVisibility**: **String** - The visibility of any headers. This defaults to `public`, but can be either:
 	- `public`
 	- `private`

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -542,7 +542,7 @@ A source can be provided via a string (the path) or an object of the form:
 	- `file`: a file reference with a parent group will be created (Default for files or directories with extensions)
 	- `group`: a group with all it's containing files. (Default for directories without extensions)
 	- `folder`: a folder reference.
-	- `synchronized`: a synchronized group that automatically updates its contents when files are added or removed in Xcode. This is useful for directories that are frequently modified.
+	- `buildableFolder`: a buildable folder that automatically updates its contents when files are added or removed in Xcode. This is useful for directories that are frequently modified.
 - [ ] **headerVisibility**: **String** - The visibility of any headers. This defaults to `public`, but can be either:
 	- `public`
 	- `private`
@@ -581,7 +581,7 @@ targets:
       - path: Resources
         type: folder
       - path: Sources
-        type: synchronized
+        type: buildableFolder
       - path: Path/To/File.asset
         resourceTags: [tag1, tag2]
 ```

--- a/Package.resolved
+++ b/Package.resolved
@@ -75,10 +75,10 @@
     {
       "identity" : "xcodeproj",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tuist/XcodeProj.git",
+      "location" : "https://github.com/locketlabs/XcodeProj.git",
       "state" : {
-        "revision" : "447c159b0c5fb047a024fd8d942d4a76cf47dde0",
-        "version" : "8.16.0"
+        "branch" : "main",
+        "revision" : "b91cc3b2e55285350cd9a5954530aaab51a818fa"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj.git",
       "state" : {
-        "revision" : "447c159b0c5fb047a024fd8d942d4a76cf47dde0",
-        "version" : "8.16.0"
+        "revision" : "efaaec0d195ce3278980ce1991dd81b1bca42365",
+        "version" : "8.26.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .package(url: "https://github.com/yonaskolb/JSONUtilities.git", from: "4.2.0"),
         .package(url: "https://github.com/kylef/Spectre.git", from: "0.9.2"),
         .package(url: "https://github.com/onevcat/Rainbow.git", from: "4.0.0"),
-        .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.16.0"),
+        .package(url: "https://github.com/locketlabs/XcodeProj.git", branch: "main"),
         .package(url: "https://github.com/jakeheis/SwiftCLI.git", from: "6.0.3"),
         .package(url: "https://github.com/mxcl/Version", from: "2.0.0"),
         .package(url: "https://github.com/freddi-kit/ArtifactBundleGen", exact: "0.0.6")

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .package(url: "https://github.com/yonaskolb/JSONUtilities.git", from: "4.2.0"),
         .package(url: "https://github.com/kylef/Spectre.git", from: "0.9.2"),
         .package(url: "https://github.com/onevcat/Rainbow.git", from: "4.0.0"),
-        .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.16.0"),
+        .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.26.0"),
         .package(url: "https://github.com/jakeheis/SwiftCLI.git", from: "6.0.3"),
         .package(url: "https://github.com/mxcl/Version", from: "2.0.0"),
         .package(url: "https://github.com/freddi-kit/ArtifactBundleGen", exact: "0.0.6")

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -138,7 +138,6 @@ public struct Scheme: Equatable {
         public var postActions: [ExecutionAction]
         public var environmentVariables: [XCScheme.EnvironmentVariable]
         public var enableGPUFrameCaptureMode: XCScheme.LaunchAction.GPUFrameCaptureMode
-        public var enableGPUValidationMode: XCScheme.LaunchAction.GPUValidationMode
         public var disableMainThreadChecker: Bool
         public var stopOnEveryMainThreadCheckerIssue: Bool
         public var disableThreadPerformanceChecker: Bool
@@ -161,7 +160,6 @@ public struct Scheme: Equatable {
             postActions: [ExecutionAction] = [],
             environmentVariables: [XCScheme.EnvironmentVariable] = [],
             enableGPUFrameCaptureMode: XCScheme.LaunchAction.GPUFrameCaptureMode = XCScheme.LaunchAction.defaultGPUFrameCaptureMode,
-            enableGPUValidationMode: XCScheme.LaunchAction.GPUValidationMode = XCScheme.LaunchAction.GPUValidationMode.enabled,
             disableMainThreadChecker: Bool = disableMainThreadCheckerDefault,
             stopOnEveryMainThreadCheckerIssue: Bool = stopOnEveryMainThreadCheckerIssueDefault,
             disableThreadPerformanceChecker: Bool = disableThreadPerformanceCheckerDefault,
@@ -182,7 +180,6 @@ public struct Scheme: Equatable {
             self.environmentVariables = environmentVariables
             self.disableMainThreadChecker = disableMainThreadChecker
             self.enableGPUFrameCaptureMode = enableGPUFrameCaptureMode
-            self.enableGPUValidationMode = enableGPUValidationMode
             self.stopOnEveryMainThreadCheckerIssue = stopOnEveryMainThreadCheckerIssue
             self.disableThreadPerformanceChecker = disableThreadPerformanceChecker
             self.language = language
@@ -484,11 +481,6 @@ extension Scheme.Run: JSONObjectConvertible {
         } else {
             enableGPUFrameCaptureMode = XCScheme.LaunchAction.defaultGPUFrameCaptureMode
         }
-        if let gpuValidationMode: String = jsonDictionary.json(atKeyPath: "enableGPUValidationMode") {
-            enableGPUValidationMode = XCScheme.LaunchAction.GPUValidationMode.fromJSONValue(gpuValidationMode)
-        } else {
-            enableGPUValidationMode = XCScheme.LaunchAction.defaultGPUValidationMode
-        }
         disableMainThreadChecker = jsonDictionary.json(atKeyPath: "disableMainThreadChecker") ?? Scheme.Run.disableMainThreadCheckerDefault
         stopOnEveryMainThreadCheckerIssue = jsonDictionary.json(atKeyPath: "stopOnEveryMainThreadCheckerIssue") ?? Scheme.Run.stopOnEveryMainThreadCheckerIssueDefault
         disableThreadPerformanceChecker = jsonDictionary.json(atKeyPath: "disableThreadPerformanceChecker") ?? Scheme.Run.disableThreadPerformanceCheckerDefault
@@ -533,10 +525,6 @@ extension Scheme.Run: JSONEncodable {
 
         if enableGPUFrameCaptureMode != XCScheme.LaunchAction.defaultGPUFrameCaptureMode {
             dict["enableGPUFrameCaptureMode"] = enableGPUFrameCaptureMode.toJSONValue()
-        }
-        
-        if enableGPUValidationMode != XCScheme.LaunchAction.defaultGPUValidationMode {
-            dict["enableGPUValidationMode"] = enableGPUValidationMode.toJSONValue()
         }
 
         if disableMainThreadChecker != Scheme.Run.disableMainThreadCheckerDefault {
@@ -989,32 +977,6 @@ extension XCScheme.LaunchAction.GPUFrameCaptureMode: JSONEncodable {
             return .disabled
         default:
             fatalError("Invalid enableGPUFrameCaptureMode value. Valid values are: autoEnabled, metal, openGL, disabled")
-        }
-    }
-}
-
-extension XCScheme.LaunchAction.GPUValidationMode: JSONEncodable {
-    public func toJSONValue() -> Any {
-        switch self {
-        case .enabled:
-            return "enabled"
-        case .disabled:
-            return "disabled"
-        case .extended:
-            return "extended"
-        }
-    }
-    
-    static func fromJSONValue(_ string: String) -> XCScheme.LaunchAction.GPUValidationMode {
-        switch string {
-        case "enabled":
-            return .enabled
-        case "disabled":
-            return .disabled
-        case "extended":
-            return .extended
-        default:
-            fatalError("Invalid enableGPUValidationMode value. Valid values are: enable, disable, extended")
         }
     }
 }

--- a/Sources/ProjectSpec/SourceType.swift
+++ b/Sources/ProjectSpec/SourceType.swift
@@ -11,5 +11,5 @@ public enum SourceType: String {
     case group
     case file
     case folder
-    case synchronized
+    case buildableFolder
 }

--- a/Sources/ProjectSpec/SourceType.swift
+++ b/Sources/ProjectSpec/SourceType.swift
@@ -11,4 +11,5 @@ public enum SourceType: String {
     case group
     case file
     case folder
+    case synchronized
 }

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -691,6 +691,15 @@ public class PBXProjGenerator {
 
         var dependencies: [PBXTargetDependency] = []
         var targetFrameworkBuildFiles: [PBXBuildFile] = []
+        var fileSystemSynchronizedGroups: [PBXFileSystemSynchronizedRootGroup] = []
+        
+        for sourceFile in sourceFiles {
+            if let synchronizedGroup = sourceFile.fileReference as? PBXFileSystemSynchronizedRootGroup {
+                fileSystemSynchronizedGroups.append(synchronizedGroup)
+                addObject(synchronizedGroup)
+            }
+        }
+        
         var frameworkBuildPaths = Set<String>()
         var customCopyDependenciesReferences: [PBXBuildFile] = []
         var copyFilesBuildPhasesFiles: [BuildPhaseSpec.CopyFilesSettings: [PBXBuildFile]] = [:]
@@ -1075,7 +1084,8 @@ public class PBXProjGenerator {
                         output.append(sourceFile)
                     }
                 }
-                .map { addObject($0.buildFile) }
+                .compactMap(\.buildFile)
+                .map { addObject($0) }
         }
 
         func getBuildFilesForPhase(_ buildPhase: BuildPhase) -> [PBXBuildFile] {
@@ -1449,6 +1459,7 @@ public class PBXProjGenerator {
         targetObject.buildRules = buildRules
         targetObject.packageProductDependencies = !packageDependencies.isEmpty ? packageDependencies : nil
         targetObject.product = targetFileReference
+        targetObject.fileSystemSynchronizedGroups = !fileSystemSynchronizedGroups.isEmpty ? fileSystemSynchronizedGroups : nil
         if !target.isLegacy {
             targetObject.productType = target.type
         }

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -691,12 +691,14 @@ public class PBXProjGenerator {
 
         var dependencies: [PBXTargetDependency] = []
         var targetFrameworkBuildFiles: [PBXBuildFile] = []
-        var buildableFolders: [PBXFileSystemSynchronizedRootGroup] = []
+        var buildableFolders: Set<PBXFileSystemSynchronizedRootGroup> = []
         
         for sourceFile in sourceFiles {
             if let buildableFolder = sourceFile.fileReference as? PBXFileSystemSynchronizedRootGroup {
-                buildableFolders.append(buildableFolder)
-                addObject(buildableFolder)
+                let (inserted, _) = buildableFolders.insert(buildableFolder)
+                if inserted {
+                    addObject(buildableFolder)
+                }
             }
         }
         
@@ -1459,7 +1461,7 @@ public class PBXProjGenerator {
         targetObject.buildRules = buildRules
         targetObject.packageProductDependencies = !packageDependencies.isEmpty ? packageDependencies : nil
         targetObject.product = targetFileReference
-        targetObject.fileSystemSynchronizedGroups = !buildableFolders.isEmpty ? buildableFolders : nil
+        targetObject.fileSystemSynchronizedGroups = !buildableFolders.isEmpty ? Array(buildableFolders).sorted(by: PBXFileElement.sortByNamePath) : nil
         if !target.isLegacy {
             targetObject.productType = target.type
         }

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -102,6 +102,8 @@ public class PBXProjGenerator {
                 name: project.name,
                 buildConfigurationList: buildConfigList,
                 compatibilityVersion: project.compatibilityVersion,
+                preferredProjectObjectVersion: nil,
+                minimizedProjectReferenceProxies: nil,
                 mainGroup: mainGroup,
                 developmentRegion: developmentRegion
             )
@@ -1445,7 +1447,7 @@ public class PBXProjGenerator {
         targetObject.dependencies = dependencies
         targetObject.productName = target.name
         targetObject.buildRules = buildRules
-        targetObject.packageProductDependencies = packageDependencies
+        targetObject.packageProductDependencies = !packageDependencies.isEmpty ? packageDependencies : nil
         targetObject.product = targetFileReference
         if !target.isLegacy {
             targetObject.productType = target.type
@@ -1537,7 +1539,7 @@ public class PBXProjGenerator {
                     return path.first(where: { $0.lastComponent == "Info.plist" })
                 }
             }
-            .first
+            .first?.normalize()
     }
 
     func getAllDependenciesPlusTransitiveNeedingEmbedding(target topLevelTarget: Target) -> [Dependency] {

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -691,12 +691,12 @@ public class PBXProjGenerator {
 
         var dependencies: [PBXTargetDependency] = []
         var targetFrameworkBuildFiles: [PBXBuildFile] = []
-        var fileSystemSynchronizedGroups: [PBXFileSystemSynchronizedRootGroup] = []
+        var buildableFolders: [PBXFileSystemSynchronizedRootGroup] = []
         
         for sourceFile in sourceFiles {
-            if let synchronizedGroup = sourceFile.fileReference as? PBXFileSystemSynchronizedRootGroup {
-                fileSystemSynchronizedGroups.append(synchronizedGroup)
-                addObject(synchronizedGroup)
+            if let buildableFolder = sourceFile.fileReference as? PBXFileSystemSynchronizedRootGroup {
+                buildableFolders.append(buildableFolder)
+                addObject(buildableFolder)
             }
         }
         
@@ -1459,7 +1459,7 @@ public class PBXProjGenerator {
         targetObject.buildRules = buildRules
         targetObject.packageProductDependencies = !packageDependencies.isEmpty ? packageDependencies : nil
         targetObject.product = targetFileReference
-        targetObject.fileSystemSynchronizedGroups = !fileSystemSynchronizedGroups.isEmpty ? fileSystemSynchronizedGroups : nil
+        targetObject.fileSystemSynchronizedGroups = !buildableFolders.isEmpty ? buildableFolders : nil
         if !target.isLegacy {
             targetObject.productType = target.type
         }

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -357,7 +357,6 @@ public class SchemeGenerator {
             allowLocationSimulation: allowLocationSimulation,
             locationScenarioReference: locationScenarioReference,
             enableGPUFrameCaptureMode: scheme.run?.enableGPUFrameCaptureMode ?? XCScheme.LaunchAction.defaultGPUFrameCaptureMode,
-            enableGPUValidationMode: scheme.run?.enableGPUValidationMode ?? XCScheme.LaunchAction.defaultGPUValidationMode,
             disableMainThreadChecker: scheme.run?.disableMainThreadChecker ?? Scheme.Run.disableMainThreadCheckerDefault,
             disablePerformanceAntipatternChecker: scheme.run?.disableThreadPerformanceChecker ?? Scheme.Run.disableThreadPerformanceCheckerDefault,
             stopOnEveryMainThreadCheckerIssue: scheme.run?.stopOnEveryMainThreadCheckerIssue ?? Scheme.Run.stopOnEveryMainThreadCheckerIssueDefault,

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -620,7 +620,7 @@ class SourceGenerator {
         let sourceReference: PBXFileElement
         var sourcePath = path
         switch type {
-        case .synchronized:
+        case .buildableFolder:
             let fileReferencePath = (try? path.relativePath(from: project.basePath)) ?? path
             var fileReferenceName: String? = targetSource.name ?? fileReferencePath.lastComponent
             if fileReferencePath.string == fileReferenceName {

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -16,6 +16,7 @@ class SourceGenerator {
     var rootGroups: Set<PBXFileElement> = []
     private let projectDirectory: Path?
     private var fileReferencesByPath: [String: PBXFileElement] = [:]
+    private var buildableFoldersByPath: [Path: PBXFileElement] = [:]
     private var groupsByPath: [Path: PBXGroup] = [:]
     private var variantGroupsByPath: [Path: PBXVariantGroup] = [:]
 
@@ -627,11 +628,17 @@ class SourceGenerator {
                 fileReferenceName = nil
             }
 
-            let fileReference = PBXFileSystemSynchronizedRootGroup(
-                sourceTree: .group,
-                path: fileReferencePath.string,
-                name: fileReferenceName
-            )
+            let fileReference: PBXFileElement
+            if let existingReference = buildableFoldersByPath[fileReferencePath] {
+                fileReference = existingReference
+            } else {
+                fileReference = PBXFileSystemSynchronizedRootGroup(
+                    sourceTree: .group,
+                    path: fileReferencePath.string,
+                    name: fileReferenceName
+                )
+                buildableFoldersByPath[fileReferencePath] = fileReference
+            }
             if !hasCustomParent || path.parent() == project.basePath {
                 rootGroups.insert(fileReference)
             }

--- a/Sources/XcodeGenKit/Version.swift
+++ b/Sources/XcodeGenKit/Version.swift
@@ -16,7 +16,7 @@ extension Project {
     }
 
     var objectVersion: UInt {
-        54
+        70
     }
 }
 

--- a/Tests/Fixtures/CarthageProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/CarthageProject/Project.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -314,8 +314,6 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = D91E14E36EC0B415578456F2 /* Build configuration list for PBXProject "Project" */;
 			compatibilityVersion = "Xcode 14.0";

--- a/Tests/Fixtures/SPM/FooFeature/.build/workspace-state.json
+++ b/Tests/Fixtures/SPM/FooFeature/.build/workspace-state.json
@@ -1,0 +1,11 @@
+{
+  "object" : {
+    "artifacts" : [
+
+    ],
+    "dependencies" : [
+
+    ]
+  },
+  "version" : 6
+}

--- a/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -16,6 +16,8 @@
 				D287BAAB664D1A024D9DD57E /* PBXTargetDependency */,
 			);
 			name = AggTarget;
+			packageProductDependencies = (
+			);
 			productName = AggTarget;
 		};
 /* End PBXAggregateTarget section */
@@ -235,8 +237,6 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = 425866ADA259DB93FC4AF1E3 /* Build configuration list for PBXProject "SPM" */;
 			compatibilityVersion = "Xcode 14.0";
@@ -637,6 +637,17 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		630A8CE9F2BE39704ED9D461 /* XCLocalSwiftPackageReference "FooFeature" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = FooFeature;
+		};
+		C6539B364583AE96C18CE377 /* XCLocalSwiftPackageReference "../../.." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../../..;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		348C81C327DB1710B742C370 /* XCRemoteSwiftPackageReference "Prefire" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -663,17 +674,6 @@
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCLocalSwiftPackageReference section */
-		630A8CE9F2BE39704ED9D461 /* XCLocalSwiftPackageReference "FooFeature" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = FooFeature;
-		};
-		C6539B364583AE96C18CE377 /* XCLocalSwiftPackageReference "../../.." */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../../..;
-		};
-/* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		15DB49096E2978F6BCA8D604 /* FooUI */ = {

--- a/Tests/Fixtures/SPM/SPM.xcodeproj/xcshareddata/xcschemes/App.xcscheme
+++ b/Tests/Fixtures/SPM/SPM.xcodeproj/xcshareddata/xcschemes/App.xcscheme
@@ -40,7 +40,8 @@
       </MacroExpansion>
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "XcodeGenKitTests"
@@ -50,7 +51,8 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "339863E54E2D955C00B56802"

--- a/Tests/Fixtures/TestProject/AnotherProject/AnotherProject.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/AnotherProject/AnotherProject.xcodeproj/project.pbxproj
@@ -112,8 +112,6 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = 3DFC1105373EDB6483D4BC5D /* Build configuration list for PBXProject "AnotherProject" */;
 			compatibilityVersion = "Xcode 14.0";

--- a/Tests/Fixtures/TestProject/AnotherProject/AnotherProject.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/AnotherProject/AnotherProject.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXFileReference section */

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -18,6 +18,8 @@
 				106CDB4BCFD183241A565E6C /* PBXTargetDependency */,
 			);
 			name = SuperTarget;
+			packageProductDependencies = (
+			);
 			productName = SuperTarget;
 		};
 /* End PBXAggregateTarget section */
@@ -900,6 +902,18 @@
 		FF47010E7368583405AA50CB /* SwiftyJSON.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SwiftyJSON.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		722A87DF16EB7921551C6D46 /* BuildableFolder */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = BuildableFolder;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
 		117840B4DBC04099F6779D00 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
@@ -1160,6 +1174,7 @@
 				4C7F5EB7D6F3E0E9B426AB4A /* Utilities */,
 				3FEA12CF227D41EF50E5C2DB /* Vendor */,
 				80C3A0E524EC1ABCB9149EA2 /* XPC Service */,
+				722A87DF16EB7921551C6D46 /* BuildableFolder */,
 				DAA7880242A9DE61E68026CC /* Folder */,
 				2E1E747C7BC434ADB80CC269 /* Headers */,
 				6B1603BA83AA0C7B94E45168 /* ResourceFolder */,
@@ -1598,6 +1613,7 @@
 		FCC084D4F8992BBC49983A38 /* CustomGroup */ = {
 			isa = PBXGroup;
 			children = (
+				722A87DF16EB7921551C6D46 /* BuildableFolder */,
 				EE1343F2238429D4DA9D830B /* File1.swift */,
 				BC56891DA7446EAC8C2F27EB /* File2.swift */,
 				DAA7880242A9DE61E68026CC /* Folder */,
@@ -1820,6 +1836,9 @@
 				E84285243DE0BB361A708079 /* PBXTargetDependency */,
 				E8C078B0A2A2B0E1D35694D5 /* PBXTargetDependency */,
 				981D116D40DBA0407D0E0E94 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				722A87DF16EB7921551C6D46 /* BuildableFolder */,
 			);
 			name = App_iOS;
 			packageProductDependencies = (

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_Clip.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_Clip.xcscheme
@@ -40,7 +40,8 @@
       </MacroExpansion>
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "63BFF75AA22335E3DDD5E26A"
@@ -50,7 +51,8 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "91C3E922A8482E07649971B9"

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_Scheme.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_Scheme.xcscheme
@@ -48,7 +48,8 @@
       </MacroExpansion>
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "F674B2CFC4738EEC49BAD0DA"
@@ -59,7 +60,6 @@
          </TestableReference>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES"
             testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
@@ -88,7 +88,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       enableGPUFrameCaptureMode = "3"
-      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Production.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Production.xcscheme
@@ -42,7 +42,8 @@
       </MacroExpansion>
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "DC2F16BAA6E13B44AB62F888"
@@ -52,7 +53,8 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "F674B2CFC4738EEC49BAD0DA"

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Staging.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Staging.xcscheme
@@ -42,7 +42,8 @@
       </MacroExpansion>
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "DC2F16BAA6E13B44AB62F888"
@@ -52,7 +53,8 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "F674B2CFC4738EEC49BAD0DA"

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Test.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Test.xcscheme
@@ -42,7 +42,8 @@
       </MacroExpansion>
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "DC2F16BAA6E13B44AB62F888"
@@ -52,7 +53,8 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "F674B2CFC4738EEC49BAD0DA"

--- a/Tests/Fixtures/TestProject/project.yml
+++ b/Tests/Fixtures/TestProject/project.yml
@@ -145,6 +145,11 @@ targets:
         type: folder
         buildPhase: none
         group: CustomGroup
+      - path: BuildableFolder
+        type: buildableFolder
+      - path: BuildableFolder
+        type: buildableFolder
+        group: CustomGroup
       - path: Mintfile
         type: file
         buildPhase: none

--- a/Tests/Fixtures/scheme_test/TestProject.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/scheme_test/TestProject.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXFileReference section */

--- a/Tests/Fixtures/scheme_test/TestProject.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/scheme_test/TestProject.xcodeproj/project.pbxproj
@@ -68,8 +68,6 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = E903F6E8184E2A86CEC31778 /* Build configuration list for PBXProject "TestProject" */;
 			compatibilityVersion = "Xcode 14.0";

--- a/Tests/XcodeGenKitTests/PBXProjGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/PBXProjGeneratorTests.swift
@@ -505,7 +505,7 @@ class PBXProjGeneratorTests: XCTestCase {
         }
     }
 
-    func testSynchronizedGroups() {
+    func testBuildableFolders() {
         describe {
             let directoryPath = Path("TestDirectory")
 
@@ -547,7 +547,7 @@ class PBXProjGeneratorTests: XCTestCase {
                 removeDirectories()
             }
 
-            $0.it("creates synchronized groups at top level and under parent groups") {
+            $0.it("creates buildable folders at top level and under parent groups") {
                 let directories = """
                     Sources:
                       - file1.swift
@@ -564,8 +564,8 @@ class PBXProjGeneratorTests: XCTestCase {
                     type: .application,
                     platform: .iOS,
                     sources: [
-                        TargetSource(path: "Sources", type: .synchronized),
-                        TargetSource(path: "Resources", group: "Assets", type: .synchronized)
+                        TargetSource(path: "Sources", type: .buildableFolder),
+                        TargetSource(path: "Resources", group: "Assets", type: .buildableFolder)
                     ]
                 )
                 let project = Project(basePath: directoryPath, name: "Test", targets: [target])
@@ -573,11 +573,11 @@ class PBXProjGeneratorTests: XCTestCase {
                 let pbxProj = try project.generatePbxProj()
                 let mainGroup = try pbxProj.getMainGroup()
 
-                // Verify top-level synchronized group
+                // Verify top-level buildable folder
                 let sourcesGroup = mainGroup.children.first { $0.path == "Sources" }
                 try expect(sourcesGroup).to.beOfType(PBXFileSystemSynchronizedRootGroup.self)
 
-                // Verify nested synchronized group
+                // Verify nested buildable folder
                 let assetsGroup = mainGroup.children.first { $0.nameOrPath == "Assets" } as? PBXGroup
                 guard let assetsGroup else {
                     throw failure("Couldn't find assets group")

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -1554,12 +1554,12 @@ class ProjectGeneratorTests: XCTestCase {
                 let pbxProject = try project.generatePbxProj(specValidate: false)
                 let nativeTarget = try unwrap(pbxProject.nativeTargets.first(where: { $0.name == app.name }))
 
-                let projectSpecDependency = try unwrap(nativeTarget.packageProductDependencies.first(where: { $0.productName == "ProjectSpec" }))
+                let projectSpecDependency = try unwrap(nativeTarget.packageProductDependencies?.first(where: { $0.productName == "ProjectSpec" }))
 
                 try expect(projectSpecDependency.package?.name) == "XcodeGen"
                 try expect(projectSpecDependency.package?.versionRequirement) == .branch("master")
 
-                let codabilityDependency = try unwrap(nativeTarget.packageProductDependencies.first(where: { $0.productName == "Codability" }))
+                let codabilityDependency = try unwrap(nativeTarget.packageProductDependencies?.first(where: { $0.productName == "Codability" }))
 
                 try expect(codabilityDependency.package?.name) == "Codability"
                 try expect(codabilityDependency.package?.versionRequirement) == .exact("1.0.0")


### PR DESCRIPTION
- Update XcodeProj to 8.26.0
- Add synchronized source type support
- Add docs
- Add synchronized group support
- Rename to buildable folder
- XcodeProj version updates
- Ensure `fileSystemSynchronizedGroups` is set
- Update to use vendored XcodeProj with filesystemSynchronized fixes
- Update test fixture with buildable folders
